### PR TITLE
Implement DAO crud operations and DatabaseExecutor

### DIFF
--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -1,137 +1,37 @@
 package app;
 
 import app.config.HibernateConfig;
-import app.dtos.ActorDTO;
-import app.dtos.DirectorDTO;
-import app.dtos.DiscoverMovieDTO;
-import app.dtos.GenreDTO;
-import app.entities.*;
-import app.services.FetchTools;
+import app.daos.*;
+import app.entities.AllEntitiesLists;
 import app.services.ImportService;
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 public class Main {
     private static EntityManagerFactory emf;
-    private static EntityManager em;
     private static ImportService is;
 
     public static void main(String[] args) throws InterruptedException {
-
         emf = HibernateConfig.getEntityManagerFactory("movies");
-        em = emf.createEntityManager();
-        em.getTransaction().begin();
         is = new ImportService();
 
-        FetchTools newFetch = new FetchTools();
-
+        //Load ind i listen
         long startTime = System.currentTimeMillis();
-        is.movieService();
-
-//        List<DiscoverMovieDTO> movies = newFetch.getAllDanishMovies();
-
-//        List<DiscoverMovieDTO.MovieResult> movieResultsList = new ArrayList<>();
-//        List<Movie> moviesAsEntities = new ArrayList<>();
-//        List<Genre> genresAsEntities = new ArrayList<>();
-//        List<Actor> actorsAsEntities = new ArrayList<>();
-//        List<Director> directorsAsEntities = new ArrayList<>();
-//
-//        List<MovieActorRelations> movieActorRelationsAsEntities = new ArrayList<>();
-//        List<MovieDirectorRelations> movieDirectorRelationsAsEntities = new ArrayList<>();
-//
-//        List<DirectorDTO.Director> directorList = new ArrayList<>();
-//        List<ActorDTO.Actor> actorList = new ArrayList<>();
-//        List<GenreDTO.Genre> genreList = new ArrayList<>();
-//        for (DiscoverMovieDTO discoverMovieDTO : movies){
-//            movieResultsList = discoverMovieDTO.getResults();
-//
-//
-//            for (DiscoverMovieDTO.MovieResult movieResult : movieResultsList){
-//                Movie movie = new Movie().builder()
-//                        .id(movieResult.getId())
-//                        .overview(movieResult.getOverview())
-//                        .popularity(movieResult.getPopularity())
-//                        .originalLanguage(movieResult.getOriginalLanguage())
-//                        .originalTitle(movieResult.getOriginalTitle())
-//                        .releaseDate(movieResult.getReleaseDate())
-//                        .voteAverage(movieResult.getVoteAverage())
-//                        .voteCount(movieResult.getVoteCount())
-//                        .build();
-//                moviesAsEntities.add(movie);
-//
-//                List<DirectorDTO> directorDTOs = newFetch.getDirectorsForMovieByMovieId(movieResult.getId());
-//                for (DirectorDTO directorDTO : directorDTOs) {
-//                    directorList = directorDTO.getDirectors();
-//                }
-//
-//                List<ActorDTO> actorDTOs = newFetch.getActorsForMovieByMovieId(movieResult.getId());
-//                for (ActorDTO actorDTO : actorDTOs) {
-//                    actorList = actorDTO.getActors();
-//                }
-//
-//                List<GenreDTO> genreDTOs = newFetch.getGenresForMovieByMovieId(movieResult.getId());
-//                for (GenreDTO genreDTO : genreDTOs){
-//                    genreList = genreDTO.getGenres();
-//                }
-//
-//                for (DirectorDTO.Director director : directorList) {
-//                    Director director1 = new Director().builder()
-//                            .id(director.getId())
-//                            .directorsName(director.getDirectorsName())
-//                            .popularity(director.getPopularity())
-//                            .build();
-//                    directorsAsEntities.add(director1);
-//
-//                    MovieDirectorRelations movieDirectorRelations = new MovieDirectorRelations().builder()
-//                            .movie(movie)
-//                            .director(director1)
-//                            .jobTitle(director.getJobTitle())
-//                            .build();
-//                    movieDirectorRelationsAsEntities.add(movieDirectorRelations);
-//                }
-//
-//                for (ActorDTO.Actor actor : actorList) {
-//                    Actor actor1 = new Actor().builder()
-//                            .id(actor.getId())
-//                            .actorsName(actor.getActorsName())
-//                            .popularity(actor.getPopularity())
-//                            .build();
-//                    actorsAsEntities.add(actor1);
-//
-//                    MovieActorRelations movieActorRelations = new MovieActorRelations().builder()
-//                            .actor(actor1)
-//                            .castId(actor.getCastId())
-//                            .movie(movie).build();
-//                    movieActorRelationsAsEntities.add(movieActorRelations);
-//                }
-//
-//                for (GenreDTO.Genre genre : genreList) {
-//                    Genre genre1 = new Genre().builder()
-//                            .id(genre.getId())
-//                            .genreName(genre.getGenreName())
-//                            .build();
-//                    genresAsEntities.add(genre1);
-//                }
-//
-//
-//            }
-//        }
+        AllEntitiesLists lists = is.movieService();
         long endTime = System.currentTimeMillis();
-        long duration = endTime - startTime;
-        System.out.println("Task runtime: " + duration + " milliseconds");
+        System.out.println("Task runtime: " + (endTime - startTime) + " ms");
 
+        // Opret DAOerne og DaoHandler
+        DaoHandler daohandler = new DaoHandler(new MovieDAO(emf), new ActorsDAO(emf), new DirectorsDAO(emf), new MovieActorRelationsDAO(emf), new MovieDirectorRelationsDAO(emf), lists);
+
+        //execute database operations
+        //Vil merge hvis data i databasen allerede findes
         startTime = System.currentTimeMillis();
-
+        System.out.println("Executing database Operations...");
+        daohandler.executeDatabaseOperations();
         endTime = System.currentTimeMillis();
-        duration = endTime - startTime;
-        System.out.println("Task runtime: " + duration + " milliseconds");
+        System.out.println("Database operations runtime: " + (endTime - startTime) + " ms");
 
-
-        em.close();
+        emf.close();
     }
-
 }

--- a/src/main/java/app/config/HibernateConfig.java
+++ b/src/main/java/app/config/HibernateConfig.java
@@ -33,7 +33,7 @@ public class HibernateConfig {
     public static EntityManagerFactory getEntityManagerFactoryForTest(String testDBName) {
         if (emfTest == null){
             setTest(true);
-            emfTest = createEMF(getTest(), testDBName);  // No DB needed for test
+            emfTest = createEMF(getTest(), testDBName);
         }
         return emfTest;
     }
@@ -53,7 +53,7 @@ public class HibernateConfig {
         try {
             Configuration configuration = new Configuration();
             Properties props = new Properties();
-            // Set the properties
+
             setBaseProperties(props);
             if (forTest) {
                 props = setTestProperties(props);
@@ -80,7 +80,7 @@ public class HibernateConfig {
 
     private static Properties setBaseProperties(Properties props) {
         props.put("hibernate.connection.driver_class", "org.postgresql.Driver");
-        props.put("hibernate.hbm2ddl.auto", "create");  // set to "update" when in production
+        props.put("hibernate.hbm2ddl.auto", "create");
         props.put("hibernate.current_session_context_class", "thread");
         props.put("hibernate.show_sql", "false");
         props.put("hibernate.format_sql", "false");

--- a/src/main/java/app/daos/ActorsDAO.java
+++ b/src/main/java/app/daos/ActorsDAO.java
@@ -1,0 +1,107 @@
+package app.daos;
+
+import app.entities.Actor;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ActorsDAO implements IDAO<Actor, Integer> {
+    private final EntityManagerFactory emf;
+    private final List<Actor> actors;
+
+    public ActorsDAO(EntityManagerFactory emf) {
+        this.emf = emf;
+        this.actors = new ArrayList<>();
+    }
+
+    @Override
+    public List<Actor> create(List<Actor> actors) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            for (Actor actor : actors) {
+                actor.setId(null);
+                em.merge(actor);
+                this.actors.add(actor);
+            }
+            em.getTransaction().commit();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not persist actors", e);
+        }
+        return actors;
+    }
+
+    @Override
+    public Actor create(Actor actor) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            em.merge(actor);
+            em.getTransaction().commit();
+            this.actors.add(actor);
+            return actor;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not persist actor", e);
+        }
+    }
+
+    @Override
+    public Actor getById(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.find(Actor.class, id);
+        }
+    }
+
+    @Override
+    public List<Actor> getAll() {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.createQuery("SELECT a FROM Actor a", Actor.class).getResultList();
+        }
+    }
+
+    @Override
+    public Actor update(Actor actor) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            Actor existing = em.find(Actor.class, actor.getId());
+            if (existing == null) {
+                em.getTransaction().rollback();
+                return null;
+            }
+            existing.setActorsName(actor.getActorsName());
+            existing.setPopularity(actor.getPopularity());
+
+            Actor merged = em.merge(existing);
+            em.getTransaction().commit();
+
+            this.actors.removeIf(a -> a.getId().equals(merged.getId()));
+            this.actors.add(merged);
+            return merged;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not update actor", e);
+        }
+    }
+
+    @Override
+    public boolean delete(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            Actor actor = em.find(Actor.class, id);
+            if (actor == null) {
+                em.getTransaction().rollback();
+                return false;
+            }
+            em.remove(actor);
+            em.getTransaction().commit();
+            for (int i = 0; i < actors.size(); i++) {
+                if (actors.get(i).getId().equals(id)) {
+                    actors.remove(i);
+                    break;
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not delete actor", e);
+        }
+    }
+}

--- a/src/main/java/app/daos/DaoHandler.java
+++ b/src/main/java/app/daos/DaoHandler.java
@@ -1,0 +1,40 @@
+package app.daos;
+
+import app.entities.*;
+
+import java.util.List;
+
+public class DaoHandler {
+    private MovieDAO movieDAO;
+    private ActorsDAO actorsDAO;
+    private DirectorsDAO directorsDAO;
+    private MovieActorRelationsDAO movieActorRelationsDAO;
+    private MovieDirectorRelationsDAO movieDirectorRelationsDAO;
+    private AllEntitiesLists allEntitiesLists;
+
+    public DaoHandler(MovieDAO movieDAO, ActorsDAO actorsDAO, DirectorsDAO directorsDAO, MovieActorRelationsDAO movieActorRelationsDAO, MovieDirectorRelationsDAO movieDirectorRelationsDAO, AllEntitiesLists allEntitiesLists) {
+        this.movieDAO = movieDAO;
+        this.actorsDAO = actorsDAO;
+        this.directorsDAO = directorsDAO;
+        this.movieActorRelationsDAO = movieActorRelationsDAO;
+        this.movieDirectorRelationsDAO = movieDirectorRelationsDAO;
+        this.allEntitiesLists = allEntitiesLists;
+    }
+
+    public void executeDatabaseOperations() {
+        if (allEntitiesLists == null)
+            return;
+
+        List<Movie> movies = allEntitiesLists.getMovies();
+        List<Actor> actors = allEntitiesLists.getActors();
+        List<Director> directors = allEntitiesLists.getDirectors();
+        List<MovieActorRelations> mar = allEntitiesLists.getMovieActorRelations();
+        List<MovieDirectorRelations> mdr = allEntitiesLists.getMovieDirectorRelations();
+
+        if (!actors.isEmpty()) actorsDAO.create(actors);
+        if (!directors.isEmpty()) directorsDAO.create(directors);
+        if (!movies.isEmpty()) movieDAO.create(movies);
+        if (!mar.isEmpty()) movieActorRelationsDAO.create(mar);
+        if (!mdr.isEmpty()) movieDirectorRelationsDAO.create(mdr);
+    }
+}

--- a/src/main/java/app/daos/DirectorsDAO.java
+++ b/src/main/java/app/daos/DirectorsDAO.java
@@ -1,0 +1,106 @@
+package app.daos;
+
+import app.entities.Director;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DirectorsDAO implements IDAO<Director, Integer> {
+    private final EntityManagerFactory emf;
+    private final List<Director> directors;
+
+    public DirectorsDAO(EntityManagerFactory emf) {
+        this.emf = emf;
+        this.directors = new ArrayList<>();
+    }
+
+    @Override
+    public List<Director> create(List<Director> directors) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            for (Director director : directors) {
+                director.setId(null);
+                em.merge(director);
+                this.directors.add(director);
+            }
+            em.getTransaction().commit();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not persist directors", e);
+        }
+        return directors;
+    }
+
+    @Override
+    public Director create(Director director) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            em.persist(director);
+            em.getTransaction().commit();
+            this.directors.add(director);
+            return director;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not persist director", e);
+        }
+    }
+
+    @Override
+    public Director getById(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.find(Director.class, id);
+        }
+    }
+
+    @Override
+    public List<Director> getAll() {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.createQuery("SELECT d FROM Director d", Director.class).getResultList();
+        }
+    }
+
+    @Override
+    public Director update(Director director) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            Director existing = em.find(Director.class, director.getId());
+            if (existing == null) {
+                em.getTransaction().rollback();
+                return null;
+            }
+            existing.setDirectorsName(director.getDirectorsName());
+            existing.setPopularity(director.getPopularity());
+
+            Director merged = em.merge(existing);
+            em.getTransaction().commit();
+            this.directors.removeIf(d -> d.getId().equals(merged.getId()));
+            this.directors.add(merged);
+            return merged;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not update director", e);
+        }
+    }
+
+    @Override
+    public boolean delete(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            Director director = em.find(Director.class, id);
+            if (director == null) {
+                em.getTransaction().rollback();
+                return false;
+            }
+            em.remove(director);
+            em.getTransaction().commit();
+            for (int i = 0; i < directors.size(); i++) {
+                if (directors.get(i).getId().equals(id)) {
+                    directors.remove(i);
+                    break;
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not delete director", e);
+        }
+    }
+}

--- a/src/main/java/app/daos/IDAO.java
+++ b/src/main/java/app/daos/IDAO.java
@@ -3,6 +3,8 @@ package app.daos;
 import java.util.List;
 
 public interface IDAO<T, I> {
+    List<T> create(List<T> list);
+
     T create(T t);
 
     T getById(I id);

--- a/src/main/java/app/daos/MovieActorRelationsDAO.java
+++ b/src/main/java/app/daos/MovieActorRelationsDAO.java
@@ -1,0 +1,154 @@
+package app.daos;
+
+import app.entities.Actor;
+import app.entities.Movie;
+import app.entities.MovieActorRelations;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MovieActorRelationsDAO implements IDAO<MovieActorRelations, Integer> {
+    private final EntityManagerFactory emf;
+    private final List<MovieActorRelations> relations;
+
+    public MovieActorRelationsDAO(EntityManagerFactory emf) {
+        this.emf = emf;
+        this.relations = new ArrayList<>();
+    }
+
+    @Override
+    public List<MovieActorRelations> create(List<MovieActorRelations> relationsList) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+
+            List<MovieActorRelations> managedRelations = new ArrayList<>();
+
+            for (MovieActorRelations rel : relationsList) {
+                Movie managedMovie = rel.getMovie() != null ? em.merge(rel.getMovie()) : null;
+                Actor managedActor = rel.getActor() != null ? em.merge(rel.getActor()) : null;
+
+                rel.setMovie(managedMovie);
+                rel.setActor(managedActor);
+
+                MovieActorRelations managedRel = em.merge(rel);
+                managedRelations.add(managedRel);
+                this.relations.add(managedRel);
+            }
+
+            em.getTransaction().commit();
+            return managedRelations;
+
+        } catch (Exception e) {
+            throw new RuntimeException("Could not persist movie-actor relations", e);
+        }
+    }
+
+    @Override
+    public MovieActorRelations create(MovieActorRelations relation) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            if (relation.getMovie() != null && relation.getMovie().getId() != null) {
+                Movie movieRef = em.find(Movie.class, relation.getMovie().getId());
+                relation.setMovie(movieRef);
+                if (movieRef != null) movieRef.getMovieActorRelations().add(relation);
+            }
+            if (relation.getActor() != null && relation.getActor().getId() != null) {
+                Actor actorRef = em.find(Actor.class, relation.getActor().getId());
+                relation.setActor(actorRef);
+                if (actorRef != null) actorRef.getMovieActorRelations().add(relation);
+            }
+            em.persist(relation);
+            em.getTransaction().commit();
+            this.relations.add(relation);
+            return relation;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not persist movie-actor relation", e);
+        }
+    }
+
+    @Override
+    public MovieActorRelations getById(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.find(MovieActorRelations.class, id);
+        }
+    }
+
+    @Override
+    public List<MovieActorRelations> getAll() {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.createQuery("SELECT mar FROM MovieActorRelations mar", MovieActorRelations.class).getResultList();
+        }
+    }
+
+    @Override
+    public MovieActorRelations update(MovieActorRelations relation) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            MovieActorRelations existing = em.find(MovieActorRelations.class, relation.getId());
+            if (existing == null) {
+                em.getTransaction().rollback();
+                return null;
+            }
+
+            existing.setCharacterName(relation.getCharacterName());
+            existing.setCastId(relation.getCastId());
+
+            if (relation.getMovie() != null && relation.getMovie().getId() != null) {
+                if (existing.getMovie() == null || !existing.getMovie().getId().equals(relation.getMovie().getId())) {
+
+                    if (existing.getMovie() != null) {
+                        existing.getMovie().getMovieActorRelations().remove(existing);
+                    }
+                    Movie newMovie = em.find(Movie.class, relation.getMovie().getId());
+                    existing.setMovie(newMovie);
+                    if (newMovie != null) newMovie.getMovieActorRelations().add(existing);
+                }
+            }
+
+            if (relation.getActor() != null && relation.getActor().getId() != null) {
+                if (existing.getActor() == null || !existing.getActor().getId().equals(relation.getActor().getId())) {
+                    if (existing.getActor() != null) {
+                        existing.getActor().getMovieActorRelations().remove(existing);
+                    }
+                    Actor newActor = em.find(Actor.class, relation.getActor().getId());
+                    existing.setActor(newActor);
+                    if (newActor != null) newActor.getMovieActorRelations().add(existing);
+                }
+            }
+
+            MovieActorRelations merged = em.merge(existing);
+            em.getTransaction().commit();
+            this.relations.removeIf(r -> r.getId().equals(merged.getId()));
+            this.relations.add(merged);
+            return merged;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not update movie-actor relation", e);
+        }
+    }
+
+    @Override
+    public boolean delete(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            MovieActorRelations rel = em.find(MovieActorRelations.class, id);
+            if (rel == null) {
+                em.getTransaction().rollback();
+                return false;
+            }
+            if (rel.getMovie() != null) {
+                rel.getMovie().getMovieActorRelations().remove(rel);
+            }
+            if (rel.getActor() != null) {
+                rel.getActor().getMovieActorRelations().remove(rel);
+            }
+            em.remove(rel);
+            em.getTransaction().commit();
+            this.relations.removeIf(r -> r.getId().equals(id));
+            return true;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not delete movie-actor relation", e);
+        }
+    }
+}

--- a/src/main/java/app/daos/MovieDAO.java
+++ b/src/main/java/app/daos/MovieDAO.java
@@ -1,0 +1,125 @@
+package app.daos;
+
+import app.entities.Genre;
+import app.entities.Movie;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MovieDAO implements IDAO<Movie, Integer> {
+    private final EntityManagerFactory emf;
+    private final List<Movie> movies;
+
+    public MovieDAO(EntityManagerFactory emf) {
+        this.emf = emf;
+        movies = new ArrayList<>();
+    }
+
+    public List<Movie> create(List<Movie> movies) {
+        EntityManager em = emf.createEntityManager();
+        em.getTransaction().begin();
+
+        for (Movie movie : movies) {
+            Set<Genre> managedGenres = movie.getGenres().stream().map(g -> ensureManagedGenre(em, g)).collect(Collectors.toSet());
+            movie.setGenres(managedGenres);
+            movie.setId(null);
+            em.merge(movie);
+        }
+
+        em.getTransaction().commit();
+        em.close();
+        return movies;
+    }
+
+    @Override
+    public Movie create(Movie movie) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            movie.setId(null);
+            em.merge(movie);
+            em.getTransaction().commit();
+            this.movies.add(movie);
+            return movie;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not persist movie", e);
+        }
+    }
+
+    @Override
+    public Movie getById(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.find(Movie.class, id);
+        }
+    }
+
+    @Override
+    public List<Movie> getAll() {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.createQuery("SELECT m FROM Movie m", Movie.class).getResultList();
+        }
+    }
+
+
+    @Override
+    public Movie update(Movie movie) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            Movie existingMovie = em.find(Movie.class, movie.getId());
+            if (existingMovie == null) {
+                em.getTransaction().rollback();
+                return null;
+            }
+
+            existingMovie.setOriginalTitle(movie.getOriginalTitle());
+            existingMovie.setReleaseDate(movie.getReleaseDate());
+
+            Movie mergedMovie = em.merge(existingMovie);
+            em.getTransaction().commit();
+            return mergedMovie;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not update movie", e);
+        }
+    }
+
+    @Override
+    public boolean delete(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            Movie movie = em.find(Movie.class, id);
+            if (movie == null) {
+                em.getTransaction().rollback();
+                return false;
+            }
+            em.remove(movie);
+            em.getTransaction().commit();
+            for (int i = 0; i < movies.size(); i++) {
+                if (movies.get(i).getId().equals(id)) {
+                    movies.remove(i);
+                    break;
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not delete movie", e);
+        }
+    }
+
+    private Genre ensureManagedGenre(EntityManager em, Genre genre) {
+        if (genre.getId() != null) {
+            Genre managed = em.find(Genre.class, genre.getId());
+            if (managed != null) {
+                return managed;
+            }
+        }
+
+        Genre newGenre = new Genre();
+        newGenre.setGenreName(genre.getGenreName());
+        em.persist(newGenre);
+        return newGenre;
+    }
+
+}

--- a/src/main/java/app/daos/MovieDirectorRelationsDAO.java
+++ b/src/main/java/app/daos/MovieDirectorRelationsDAO.java
@@ -1,0 +1,146 @@
+package app.daos;
+
+import app.entities.Director;
+import app.entities.Movie;
+import app.entities.MovieDirectorRelations;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MovieDirectorRelationsDAO implements IDAO<MovieDirectorRelations, Integer> {
+    private final EntityManagerFactory emf;
+    private final List<MovieDirectorRelations> relations;
+
+    public MovieDirectorRelationsDAO(EntityManagerFactory emf) {
+        this.emf = emf;
+        this.relations = new ArrayList<>();
+    }
+
+    @Override
+    public List<MovieDirectorRelations> create(List<MovieDirectorRelations> relationsList) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+
+            List<MovieDirectorRelations> managedRelations = new ArrayList<>();
+
+            for (MovieDirectorRelations rel : relationsList) {
+                Movie managedMovie = rel.getMovie() != null ? em.merge(rel.getMovie()) : null;
+                Director managedDirector = rel.getDirector() != null ? em.merge(rel.getDirector()) : null;
+
+                rel.setMovie(managedMovie);
+                rel.setDirector(managedDirector);
+
+                MovieDirectorRelations managedRel = em.merge(rel);
+                managedRelations.add(managedRel);
+                this.relations.add(managedRel);
+            }
+
+            em.getTransaction().commit();
+            return managedRelations;
+
+        } catch (Exception e) {
+            throw new RuntimeException("Could not persist movie-director relations", e);
+        }
+    }
+
+    @Override
+    public MovieDirectorRelations create(MovieDirectorRelations relation) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            if (relation.getMovie() != null && relation.getMovie().getId() != null) {
+                Movie movieRef = em.find(Movie.class, relation.getMovie().getId());
+                relation.setMovie(movieRef);
+                if (movieRef != null) movieRef.getMovieDirectorRelations().add(relation);
+            }
+            if (relation.getDirector() != null && relation.getDirector().getId() != null) {
+                Director directorRef = em.find(Director.class, relation.getDirector().getId());
+                relation.setDirector(directorRef);
+                if (directorRef != null) directorRef.getMovieDirectorRelations().add(relation);
+            }
+            em.persist(relation);
+            em.getTransaction().commit();
+            this.relations.add(relation);
+            return relation;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not persist movie-director relation", e);
+        }
+    }
+
+    @Override
+    public MovieDirectorRelations getById(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.find(MovieDirectorRelations.class, id);
+        }
+    }
+
+    @Override
+    public List<MovieDirectorRelations> getAll() {
+        try (EntityManager em = emf.createEntityManager()) {
+            return em.createQuery("SELECT mdr FROM MovieDirectorRelations mdr", MovieDirectorRelations.class)
+                    .getResultList();
+        }
+    }
+
+    @Override
+    public MovieDirectorRelations update(MovieDirectorRelations relation) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            MovieDirectorRelations existing = em.find(MovieDirectorRelations.class, relation.getId());
+            if (existing == null) {
+                em.getTransaction().rollback();
+                return null;
+            }
+
+            existing.setJobTitle(relation.getJobTitle());
+
+            if (relation.getMovie() != null && relation.getMovie().getId() != null) {
+                if (existing.getMovie() == null || !existing.getMovie().getId().equals(relation.getMovie().getId())) {
+                    if (existing.getMovie() != null) existing.getMovie().getMovieDirectorRelations().remove(existing);
+                    Movie newMovie = em.find(Movie.class, relation.getMovie().getId());
+                    existing.setMovie(newMovie);
+                    if (newMovie != null) newMovie.getMovieDirectorRelations().add(existing);
+                }
+            }
+
+            if (relation.getDirector() != null && relation.getDirector().getId() != null) {
+                if (existing.getDirector() == null || !existing.getDirector().getId().equals(relation.getDirector().getId())) {
+                    if (existing.getDirector() != null)
+                        existing.getDirector().getMovieDirectorRelations().remove(existing);
+                    Director newDirector = em.find(Director.class, relation.getDirector().getId());
+                    existing.setDirector(newDirector);
+                    if (newDirector != null) newDirector.getMovieDirectorRelations().add(existing);
+                }
+            }
+
+            MovieDirectorRelations merged = em.merge(existing);
+            em.getTransaction().commit();
+            this.relations.removeIf(r -> r.getId().equals(merged.getId()));
+            this.relations.add(merged);
+            return merged;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not update movie-director relation", e);
+        }
+    }
+
+    @Override
+    public boolean delete(Integer id) {
+        try (EntityManager em = emf.createEntityManager()) {
+            em.getTransaction().begin();
+            MovieDirectorRelations rel = em.find(MovieDirectorRelations.class, id);
+            if (rel == null) {
+                em.getTransaction().rollback();
+                return false;
+            }
+            if (rel.getMovie() != null) rel.getMovie().getMovieDirectorRelations().remove(rel);
+            if (rel.getDirector() != null) rel.getDirector().getMovieDirectorRelations().remove(rel);
+            em.remove(rel);
+            em.getTransaction().commit();
+            this.relations.removeIf(r -> r.getId().equals(id));
+            return true;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not delete movie-director relation", e);
+        }
+    }
+}

--- a/src/main/java/app/entities/AllEntitiesLists.java
+++ b/src/main/java/app/entities/AllEntitiesLists.java
@@ -1,21 +1,25 @@
 package app.entities;
 
+import lombok.Getter;
+
 import java.util.List;
+
+@Getter
 
 public class AllEntitiesLists {
     List<Director> directors;
-    List<Genre> genres;
     List<Actor> actors;
     List<Movie> movies;
     List<MovieActorRelations> movieActorRelations;
     List<MovieDirectorRelations> movieDirectorRelations;
 
-    public AllEntitiesLists(List<Director> directors, List<Genre> genres, List<Actor> actors, List<Movie> movies, List<MovieActorRelations> movieActorRelations, List<MovieDirectorRelations> movieDirectorRelations) {
+    public AllEntitiesLists(List<Director> directors, List<Actor> actors, List<Movie> movies, List<MovieActorRelations> movieActorRelations, List<MovieDirectorRelations> movieDirectorRelations) {
         this.directors = directors;
-        this.genres = genres;
         this.actors = actors;
         this.movies = movies;
         this.movieActorRelations = movieActorRelations;
         this.movieDirectorRelations = movieDirectorRelations;
     }
+
+
 }

--- a/src/main/java/app/entities/Movie.java
+++ b/src/main/java/app/entities/Movie.java
@@ -23,13 +23,14 @@ public class Movie {
     private Integer id;
     private String originalLanguage;
     private String originalTitle;
+    @Column(columnDefinition = "TEXT")
     private String overview;
     private double popularity;
     private LocalDate releaseDate;
     private double voteAverage;
     private int voteCount;
 
-    @ManyToMany
+    @ManyToMany(cascade = CascadeType.PERSIST)
     @JoinTable(
             name = "movie_genre",
             joinColumns = @JoinColumn(name = "movie_id"),

--- a/src/main/java/app/services/FetchTools.java
+++ b/src/main/java/app/services/FetchTools.java
@@ -100,7 +100,6 @@ public class FetchTools {
     }
 
     public List<DirectorDTO.Director> getDirectorsForMovieByMovieId(Integer movieId) {
-        //System.out.println("Starting director for movie by movieid: " + movieId + " fetch..." );
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         List<DirectorDTO.Director> directors = new ArrayList<>();
@@ -126,7 +125,6 @@ public class FetchTools {
 
             List<DirectorDTO.Director> directorList = directorDTO.getDirectors();
 
-
             for (DirectorDTO.Director director : directorList) {
                 if (director.getDepartment().equalsIgnoreCase("Directing")) directors.add(director);
             }
@@ -140,7 +138,6 @@ public class FetchTools {
     }
 
     public List<ActorDTO.Actor> getActorsForMovieByMovieId(Integer movieId) {
-        //System.out.println("Starting Actors for movie by movieid: " + movieId + " fetch..." );
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         List<ActorDTO.Actor> actors = new ArrayList<>();
@@ -213,52 +210,4 @@ public class FetchTools {
 
         return genres;
     }
-
-//    public List<DiscoverMovieDTO> getAllDanishMovies() {
-//        System.out.println("Starting fetch...");
-//        ObjectMapper objectMapper = new ObjectMapper();
-//        objectMapper.registerModule(new JavaTimeModule());
-//        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-//        List<DiscoverMovieDTO> discoverMovieDTOS = new ArrayList<>();
-//        int page = 1;
-//        boolean hasMore = true;
-//
-//        try {
-//            while (hasMore) {
-//                String url = baseUrl + "/discover/movie?include_adult=false&include_video=false&language=en-" +
-//                        "US&page=1&release_date.gte=2020-01-01&release_date.lte=2025-09-16&sort_by=popularity.desc&" +
-//                        "with_original_language=da&api_key=" + apiKey +
-//                        "&vote_average.gte=0.0&vote_average.lte=10.0&page=" + page +
-//                        "&sort_by=release_date.desc";
-//
-//                HttpClient client = HttpClient.newHttpClient();
-//
-//                HttpRequest request = HttpRequest.newBuilder()
-//                        .uri(new URI(url))
-//                        .GET()
-//                        .build();
-//
-//                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-//                JsonNode rootNode = objectMapper.readTree(response.body());
-//
-//                if (response.statusCode() == 200) {
-//                    DiscoverMovieDTO discoverMovieDTO = objectMapper.readValue(response.body(), DiscoverMovieDTO.class);
-//                    discoverMovieDTOS.add(discoverMovieDTO);
-//
-//                    if (page >= rootNode.path("total_pages").asInt()) {
-//                        hasMore = false;
-//                    } else {
-//                        page++;
-//                    }
-//                } else {
-//                    System.out.println("Failed request, status: " + response.statusCode());
-//                    hasMore = false;
-//                }
-//            }
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//        }
-//
-//        return discoverMovieDTOS;
-//    }
 }


### PR DESCRIPTION
- Tilføjet DaoHandler som håndtere vores forskellige dao'er og tilføjer listerne til de representive Dao klasse metoder. Her bliver der kørt en daohandler.executeDatabaseOperations() som tager vores samlede entitylist og smider den ned i databasen.

- Tilføjet de resterende CRUD metoder